### PR TITLE
Add dedicated shader for colored circle overlay

### DIFF
--- a/res/graph.json
+++ b/res/graph.json
@@ -59,7 +59,7 @@
       "A": "intro_add.render",
       "C": "LaneSwipeTransition.render",
       "F": "SphereTransitionShader.render",
-      "H": "triangle.render",
+      "H": "CircleOverlayShader.render",
       "H_and_a_half": "tunnel.render",
       "I": "piano.render",
       "J": "MinecraftTransitionShader.render",
@@ -291,7 +291,17 @@
         "shader": "tunnel"
     },
     "connected": {
-        "tDiffuse": "greets.render"
+      "tDiffuse": "greets.render"
+    }
+  },
+  {
+    "id": "CircleOverlayShader",
+    "type": "CircleOverlayShaderNode",
+    "options": {
+      "shader": "CircleOverlayShader"
+    },
+    "connected": {
+      "A": "triangle.render"
     }
   }
 ]

--- a/src/CircleOverlayShaderNode.js
+++ b/src/CircleOverlayShaderNode.js
@@ -1,0 +1,31 @@
+(function(global) {
+  class CircleOverlayShaderNode extends NIN.ShaderNode {
+    constructor(id, options) {
+      options.inputs = {
+        A: new NIN.TextureInput(),
+      };
+      super(id, options);
+    }
+
+    update(frame) {
+      this.uniforms.tDiffuse.value = this.inputs.A.getValue();
+
+      let radius;
+      if(BEAN < 12 * 4 * 49 - 12 - 6) {
+      } else if(BEAN < 12 * 4 * 49 - 12 - 4) {
+        radius = 1.875;
+      } else if(BEAN < 12 * 4 * 49 - 12 - 2) {
+        radius = 1.5;
+      } else if(BEAN < 12 * 4 * 49 - 12) {
+        radius = 1.05;
+      } else if(BEAN < 12 * 4 * 49) {
+        radius = 0.75;
+      } else {
+        radius = 10;
+      }
+      this.uniforms.radius.value = radius;
+    }
+  }
+
+  global.CircleOverlayShaderNode = CircleOverlayShaderNode;
+})(this);

--- a/src/GalagaNode.js
+++ b/src/GalagaNode.js
@@ -572,31 +572,6 @@
       this.ctx.textAlign = 'left';
       this.ctx.fillText(health, 13.8 * GU, (hudOffset + 8.6) * GU);
 
-      if(BEAN >= 12 * 4 * 49 - 12 - 6) {
-        const ctx = this.maskCanvas.getContext('2d');
-        ctx.clearRect(0, 0, this.maskCanvas.width, this.maskCanvas.height);
-        ctx.fillRect(0, 0, this.maskCanvas.width, this.maskCanvas.height);
-        ctx.globalCompositeOperation = 'xor';
-        ctx.fillStyle = '#20db7a';
-        let radius;
-        if(BEAN < 12 * 4 * 49 - 12 - 4) {
-          radius = 7.5;
-        } else if(BEAN < 12 * 4 * 49 - 12 - 2) {
-          radius = 6;
-        } else if(BEAN < 12 * 4 * 49 - 12) {
-          radius = 4.2;
-        } else {
-          radius = 3;
-        }
-        ctx.beginPath();
-        ctx.ellipse(8 * GU, 4.5 * GU, radius * GU, radius * GU, 0, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.textBaseline = 'middle';
-        ctx.textAlign = 'center';
-        ctx.font = (1.2 * GU) + 'pt vcr'; 
-        this.ctx.drawImage(this.maskCanvas, 0, 0);
-      }
-
       this.output.needsUpdate = true;
       this.outputs.render.setValue(this.output);
     }

--- a/src/shaders/CircleOverlayShader/fragment.glsl
+++ b/src/shaders/CircleOverlayShader/fragment.glsl
@@ -1,0 +1,16 @@
+uniform float radius;
+uniform sampler2D tDiffuse;
+
+varying vec2 vUv;
+
+void main() {
+    vec4 bg = texture2D(tDiffuse, vUv);
+    vec2 uv = -1.0 + 2.0 * vUv;
+    uv.x *= 16.0/9.0;
+
+    if (length(uv) > radius) {
+      gl_FragColor = vec4(0.125, 0.859, 0.478, 1.0);
+    } else {
+      gl_FragColor = bg;
+    }
+}

--- a/src/shaders/CircleOverlayShader/uniforms.json
+++ b/src/shaders/CircleOverlayShader/uniforms.json
@@ -1,0 +1,4 @@
+{
+    "tDiffuse": { "type": "t", "value": null },
+    "radius": { "type": "f", "value": 0.0 }
+}

--- a/src/shaders/CircleOverlayShader/vertex.glsl
+++ b/src/shaders/CircleOverlayShader/vertex.glsl
@@ -1,0 +1,8 @@
+uniform sampler2D tDiffuse;
+
+varying vec2 vUv;
+
+void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}


### PR DESCRIPTION

<img width="649" alt="screenshot 2017-04-14 18 09 16" src="https://cloud.githubusercontent.com/assets/1413267/25048583/7cef28ec-213d-11e7-902d-9f6de6a0b5c1.png">
This lets us put the circle overlay on top of the blob shader, making
the blob itself not see and reflect the overlay.
Because of the change there is currently no vignette on top of the
overlay, but it should be possible to move some vignettes around to get
this back if we want to.